### PR TITLE
feat: Send lockExcludedAuthPartners during auth lock for Resident Portal (#1566)

### DIFF
--- a/resident-ui/src/app/feature/uinservices/lockunlockauth/lockunlockauth.component.ts
+++ b/resident-ui/src/app/feature/uinservices/lockunlockauth/lockunlockauth.component.ts
@@ -226,17 +226,32 @@ export class LockunlockauthComponent implements OnInit, OnDestroy {
   updateAuthlockStatus(){
     this.showSpinner = true;
     let buildfinaldata = [];
-    this.authlist.forEach(item =>{
-      if(item.authSubType){
-        if(this.changedItems.includes(item.authSubType)){
-            buildfinaldata.push(item)
+
+    // AC10: read exclusion-supported auth types from config
+    const exclusionConfig = this.appConfigService.getConfig()["resident.auth-types-groups.exclusion-for-resident-login"];
+    const exclusionSupportedTypes: string[] = exclusionConfig ? JSON.parse(exclusionConfig) : [];
+
+    // AC9: read resident partner ID from config, not hardcoded
+    const residentPartnerId = this.appConfigService.getConfig()["mosip-resident-service-partner-id"] || "resident-partner";
+
+    this.authlist.forEach(item => {
+      const authKey = item.authSubType
+        ? `${item.authType}-${item.authSubType}`
+        : item.authType;
+
+      const isChanged = item.authSubType
+        ? this.changedItems.includes(item.authSubType)
+        : this.changedItems.includes(item.authType);
+
+      if (isChanged) {
+        // AC8: attach lockExcludedAuthPartners only when locking and auth type supports exclusion
+        const enrichedItem = { ...item };
+        if (item.locked && exclusionSupportedTypes.includes(authKey)) {
+          enrichedItem["lockExcludedAuthPartners"] = [residentPartnerId];
         }
-      }else{
-        if(this.changedItems.includes(item.authType)){
-          buildfinaldata.push(item)
-        }
+        buildfinaldata.push(enrichedItem);
       }
-    })
+    });
 
     const request = {
       "id": "mosip.resident.auth.lock.unlock",

--- a/resident-ui/src/app/feature/uinservices/lockunlockauth/lockunlockauth.component.ts
+++ b/resident-ui/src/app/feature/uinservices/lockunlockauth/lockunlockauth.component.ts
@@ -229,7 +229,12 @@ export class LockunlockauthComponent implements OnInit, OnDestroy {
 
     // AC10: read exclusion-supported auth types from config
     const exclusionConfig = this.appConfigService.getConfig()["resident.auth-types-groups.exclusion-for-resident-login"];
-    const exclusionSupportedTypes: string[] = exclusionConfig ? JSON.parse(exclusionConfig) : [];
+    let exclusionSupportedTypes: string[] = [];
+    try {
+      exclusionSupportedTypes = exclusionConfig ? JSON.parse(exclusionConfig) : [];
+    } catch (e) {
+      exclusionSupportedTypes = [];
+    }
 
     // AC9: read resident partner ID from config, not hardcoded
     const residentPartnerId = this.appConfigService.getConfig()["mosip-resident-service-partner-id"] || "resident-partner";


### PR DESCRIPTION

Implements the Angular/UI side of the authentication lock exclusion mechanism for the Resident Portal.
Problem
When a resident locks all auth types, they get deadlocked out of the portal with no way to recover.
Changes
lockunlockauth.component.ts — Modified updateAuthlockStatus() to attach lockExcludedAuthPartners: ["resident-partner"] to the lock payload, only for auth types listed in the exclusion config and only during lock (not unlock). Non-matching auth types behave exactly as before.
app-config.service.ts — Added mapping for resident.auth-types-groups.exclusion-for-resident-login and mosip-resident-service-partner-id from the backend config endpoint.
Acceptance Criteria covered

AC8 ✅ lockExcludedAuthPartners sent during lock operations
AC9 ✅ Partner ID sourced from mosip-resident-service-partner-id config, not hardcoded
AC10 ✅ Supported auth types driven by resident.auth-types-groups.exclusion-for-resident-login
AC11 ✅ If config absent, falls back to existing behavior
AC13 ✅ Unlock flow and non-excluded auth types untouched

Linked Issue: mosip/resident-services#1566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication lock/unlock status updates to properly consider application configuration for exclusion rules, ensuring authentication partner-specific exclusions are correctly applied when managing authentication methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->