### PR TITLE
Add MOSIP ownership notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+All MOSIP code is owned and maintained by International Institute of Information Technology, Bangalore, on behalf of MOSIP
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
This PR prepends the following line to the top of the LICENSE file:\n\n> All MOSIP code is owned and maintained by International Institute of Information Technology, Bangalore, on behalf of MOSIP\n\nNo other content is modified.