### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ first. See the module `AGENTS.md` files for full command lists:
 
 ```bash
 # Angular app
-(cd resident-ui && npm install && npm run build && npm test && npm run lint)
+(cd resident-ui && npm install && npm run build && npm test -- --watch=false && npm run lint)
 
 # Selenium test rig
 (cd uitest-resident && mvn clean install)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,170 @@
+# AGENTS.md
+
+## Repository Overview
+
+`resident-ui` is the reference implementation of the Resident UI for MOSIP
+(Modular Open Source Identity Platform). It is the web portal residents use
+to view their identity data, download UIN/VID cards, raise service
+requests, and manage consent/sharing with partners.
+
+The repository holds two independent, separately-built projects plus
+deployment assets:
+
+- `resident-ui/` — the Angular web application (the actual product).
+- `uitest-resident/` — a Maven/Java Selenium test-automation module that
+  drives the deployed UI end-to-end.
+- `helm/resident-ui/` — the Helm chart used to deploy the built UI image.
+- `deploy/resident-ui/` and `deploy/resident-uitestrig/` — install/restart/
+  delete shell scripts that wrap the Helm chart for cluster rollout.
+
+Each of `resident-ui/` and `uitest-resident/` has its own build stack, its
+own commands, and its own `AGENTS.md` with the specifics:
+
+- [`resident-ui/AGENTS.md`](resident-ui/AGENTS.md) — Angular app: build,
+  lint, unit tests, e2e, Docker image, runtime config.
+- [`uitest-resident/AGENTS.md`](uitest-resident/AGENTS.md) — Maven-based
+  Selenium test rig: build, configuration, execution, tags.
+
+Read this root file for repo-wide conventions, then the relevant subfolder
+file for the module you are changing.
+
+## Technology Stack
+
+| Area | Stack |
+|---|---|
+| UI app | Angular 7, TypeScript 3.2, Angular CLI 7.2, RxJS 6 |
+| UI unit tests | Karma + Jasmine |
+| UI e2e tests | Protractor |
+| UI web server (container) | nginx |
+| Test automation module | Java, Maven, Selenium WebDriver |
+| Deployment | Docker, Helm 3, Kubernetes (via shell scripts in `deploy/`) |
+| CI | GitHub Actions, reusable workflows from `mosip/kattu` |
+
+There is a root-level `package-lock.json`, but it is an empty stub
+(`"packages": {}`) — it is not a real Node project manifest. The real
+Angular project and its dependencies live entirely under `resident-ui/`.
+
+## Build & Test Commands
+
+This repo has no root-level build — always `cd` into the relevant module
+first. See the module `AGENTS.md` files for full command lists:
+
+```bash
+# Angular app
+cd resident-ui
+npm install
+npm run build
+npm test
+npm run lint
+
+# Selenium test rig
+cd uitest-resident
+mvn clean install
+```
+
+## Configuration
+
+- Angular runtime config (API base URL, auth endpoints) is read from
+  `resident-ui/src/assets/config.json` at runtime — it is not compiled
+  into the JS bundle, so it can be swapped per environment without a
+  rebuild. It contains only URLs/endpoint paths, no secrets.
+- Angular build-time config (`production` flag) is in
+  `resident-ui/src/environments/environment.ts` and
+  `environment.prod.ts`, swapped by `--configuration production`
+  (see `resident-ui/angular.json` `fileReplacements`).
+- The i18n translation bundle is **not** shipped in the Docker image. The
+  container's `CMD` (`resident-ui/Dockerfile`) downloads it at container
+  start from the URL in the `resident_i18n_bundle_url_env` environment
+  variable and unzips it into `assets/i18n` before starting nginx.
+- Cluster secrets (Keycloak client secrets, OIDC client id, etc.) are
+  never hand-edited into a values file. `deploy/resident-ui/install.sh`
+  pulls them from existing Kubernetes `Secret`/`ConfigMap` objects via
+  `deploy/copy_cm_func.sh` and injects them with `helm --set` / `kubectl
+  create secret --from-literal` at install time. Do not tell contributors
+  to paste secrets into `helm/resident-ui/values.yaml`.
+- `uitest-resident` reads its own `Config.properties` and `TestData.json`
+  — see `uitest-resident/AGENTS.md`.
+
+## Project Structure Notes
+
+```text
+resident-ui/                    (repo root)
+├── resident-ui/                Angular application source
+│   ├── src/app/                 components, services, modules
+│   ├── src/assets/              runtime config, i18n, static assets
+│   ├── src/environments/        build-time environment flags
+│   ├── e2e/                     Protractor e2e specs
+│   └── Dockerfile
+├── uitest-resident/             Selenium/Maven UI test automation
+├── helm/resident-ui/            Helm chart for the UI deployment
+├── deploy/resident-ui/          install.sh / restart.sh / delete.sh wrappers
+├── deploy/resident-uitestrig/   install/delete for the test rig
+└── .github/workflows/           CI (build, docker, sonar, codeql, release)
+```
+
+The two nested directories with the same name pattern
+(`resident-ui/resident-ui/` for the app, `resident-ui/uitest-resident/`
+for the tests) are easy to confuse — always check which directory you are
+in before running `npm` or `mvn` commands.
+
+## Development Workflow
+
+1. Branch from `develop` (the active integration branch; release branches
+   and `master` also exist but `develop` is where day-to-day work lands).
+2. Make changes inside the correct module directory (`resident-ui/` or
+   `uitest-resident/`).
+3. Run the module's lint/test commands locally before pushing (see the
+   module `AGENTS.md`).
+4. Push to your fork and open a PR against `mosip/resident-ui`'s
+   `develop` branch.
+
+## Pull Request Guidelines
+
+- Target `develop`, not `master` (`master` tracks released code).
+- CI (`.github/workflows/push-trigger.yml`) runs automatically on PR
+  `opened`/`reopened`/`synchronize`: it builds `resident-ui` via the
+  shared `npm-build.yml` workflow and builds `uitest-resident` via Maven,
+  then builds Docker images for both. Sonar analysis only runs on
+  non-PR events (pushes to branches), not on the PR itself.
+- Keep changes scoped to one module per PR where practical, since the
+  two modules have unrelated stacks and reviewers.
+- There is no `CONTRIBUTING.md` or PR template in this repo at the time
+  of writing — follow the commit/PR conventions visible in recent merged
+  PRs (issue/ticket reference in the title, e.g. `MOSIP-xxxxx` or
+  `#<issue-number>`).
+
+## Repository-Specific Considerations
+
+- Angular 7 / TypeScript 3.2 is old. Do not silently bump major
+  dependency versions (Angular, TypeScript, RxJS) as a side effect of an
+  unrelated change — that is a separate, deliberate upgrade effort.
+- The root `package-lock.json` stub and the real
+  `resident-ui/package-lock.json` are different files. Only touch the
+  one under `resident-ui/` when updating app dependencies.
+- `.idea/`, `.project`, `.settings/`, `resident-ui.iml` are IDE metadata
+  checked into the repo root; do not treat them as build configuration.
+
+## Agent rules
+
+### Do
+
+1. Work inside the correct module directory (`resident-ui/` or
+   `uitest-resident/`) and use that module's own `AGENTS.md` for exact
+   commands.
+2. Verify claims about build/CI/deploy behavior against the actual files
+   (`.github/workflows/*`, `Dockerfile`, `deploy/*/install.sh`) before
+   documenting or relying on them — they change over time.
+3. Target the `develop` branch for PRs and branch-from.
+4. Treat `resident-ui/src/assets/config.json` as the place for runtime
+   endpoint config, and keep secrets out of any committed file.
+
+### Do not
+
+1. Do not run `npm` commands from the repo root — there is no real
+   Node project there, only an empty `package-lock.json` stub.
+2. Do not add secrets, tokens, or credentials to `helm/resident-ui/
+   values.yaml` or any file under `deploy/` — the install scripts pull
+   them from Kubernetes Secrets/ConfigMaps at deploy time.
+3. Do not bump Angular/TypeScript/RxJS major versions as a drive-by
+   change.
+4. Do not assume the root `package-lock.json` is the app's real lockfile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,15 +51,10 @@ first. See the module `AGENTS.md` files for full command lists:
 
 ```bash
 # Angular app
-cd resident-ui
-npm install
-npm run build
-npm test
-npm run lint
+(cd resident-ui && npm install && npm run build && npm test && npm run lint)
 
 # Selenium test rig
-cd uitest-resident
-mvn clean install
+(cd uitest-resident && mvn clean install)
 ```
 
 ## Configuration
@@ -102,10 +97,10 @@ resident-ui/                    (repo root)
 └── .github/workflows/           CI (build, docker, sonar, codeql, release)
 ```
 
-The two nested directories with the same name pattern
-(`resident-ui/resident-ui/` for the app, `resident-ui/uitest-resident/`
-for the tests) are easy to confuse — always check which directory you are
-in before running `npm` or `mvn` commands.
+The two module directories at the repo root, `resident-ui/` (the Angular
+app) and `uitest-resident/` (the Selenium test rig), are easy to confuse
+— always check which directory you are in before running `npm` or `mvn`
+commands.
 
 ## Development Workflow
 

--- a/resident-ui/AGENTS.md
+++ b/resident-ui/AGENTS.md
@@ -1,0 +1,114 @@
+# AGENTS.md — resident-ui (Angular app)
+
+Parent guide: [`../AGENTS.md`](../AGENTS.md)
+
+## Purpose
+
+The Angular 7 web application residents use to sign in, view their
+identity, download UIN/VID documents, raise service requests, and manage
+data-sharing consent with partners. This is the module that gets built
+into the `resident-ui` Docker image.
+
+## Layout
+
+```text
+resident-ui/
+├── src/
+│   ├── app/            components, services, routing, feature modules
+│   ├── assets/         config.json (runtime config), i18n, fonts, images
+│   ├── environments/   environment.ts / environment.prod.ts (build-time)
+│   └── index.html, main.ts, polyfills.ts, styles.css
+├── e2e/                 Protractor end-to-end specs
+├── angular.json          Angular CLI project/build config
+├── package.json          npm scripts and dependencies
+├── Dockerfile             nginx-based runtime image
+├── nginx.conf / default.conf   nginx server config used by the image
+└── download.conf          headers used when serving downloadable files
+```
+
+## How to run
+
+Install dependencies and start a dev server:
+
+```bash
+npm install
+npm start
+```
+
+This runs `ng serve` and serves the app at `http://localhost:4200/` with
+live reload (see the `start` script in `package.json`).
+
+## Build & Test Commands
+
+All commands run from this directory (`resident-ui/resident-ui/` from the
+repo root):
+
+```bash
+npm install         # install dependencies
+npm run build        # ng build -> output in dist/resident-ui
+npm test             # ng test -> Karma/Jasmine unit tests
+npm run lint          # ng lint -> TSLint
+npm run e2e           # ng e2e -> Protractor end-to-end tests
+npm run sonar          # sonar-scanner (requires a configured Sonar server)
+```
+
+For a production build (used by CI/Docker), Angular CLI's `production`
+configuration swaps in `environment.prod.ts` and enables optimization,
+output hashing, and no source maps:
+
+```bash
+ng build --configuration production
+```
+
+## Configuration
+
+- `src/assets/config.json` is the runtime config (API base URL, auth
+  endpoints). It is fetched by the app at runtime, not baked into the JS
+  bundle — the same built `dist/` can be pointed at different backends by
+  swapping this file. It holds only URLs/paths, no secrets.
+- `src/environments/environment.ts` (dev) and `environment.prod.ts`
+  (prod) only carry a `production: boolean` flag today — there is no
+  secret material here either.
+- The i18n bundle is **not** part of the built `dist/` output. The
+  Docker image's `CMD` downloads it at container start from the URL in
+  the `resident_i18n_bundle_url_env` environment variable and unzips it
+  into `assets/i18n` before nginx starts. If you add a new UI string,
+  update the source i18n JSON that feeds that external bundle build, not
+  a file checked into this repo.
+- `nginx.conf` / `default.conf` configure the container's nginx server;
+  `download.conf` sets `Content-Disposition: attachment` headers for
+  file-download routes.
+
+## Development Workflow
+
+1. `cd resident-ui/resident-ui` (from repo root) or just `resident-ui`
+   if you are already inside the outer `resident-ui/` checkout.
+2. `npm install`.
+3. Make your change under `src/app/...`.
+4. Run `npm run lint` and `npm test` before committing.
+5. If the change affects routed pages or user flows, also run
+   `npm run e2e` (requires Chrome/Protractor webdriver set up locally).
+
+## Agent rules — Do and Do not
+
+### Do
+
+1. Run `npm install` / `npm run build` / `npm test` / `npm run lint`
+   from inside this `resident-ui/resident-ui/` directory, never the repo
+   root.
+2. Treat `src/assets/config.json` as the file to change for API
+   endpoint/base URL config — not `environment.ts`.
+3. Keep `environment.ts` / `environment.prod.ts` limited to build-time
+   flags; do not put secrets or environment URLs there.
+4. Update `e2e/` specs when you change routed page behavior they cover.
+
+### Do not
+
+1. Do not commit an i18n bundle or edit `assets/i18n` output directly —
+   it is downloaded and unzipped at container runtime by the Dockerfile
+   `CMD`, so in-repo edits to that generated directory would be
+   overwritten.
+2. Do not bump `@angular/*`, `typescript`, or `rxjs` versions as an
+   incidental part of an unrelated fix.
+3. Do not hardcode API URLs in TypeScript source — use
+   `src/assets/config.json`.

--- a/resident-ui/AGENTS.md
+++ b/resident-ui/AGENTS.md
@@ -40,8 +40,7 @@ live reload (see the `start` script in `package.json`).
 
 ## Build & Test Commands
 
-All commands run from this directory (`resident-ui/resident-ui/` from the
-repo root):
+All commands run from this directory (`resident-ui/` from the repo root):
 
 ```bash
 npm install         # install dependencies
@@ -81,8 +80,7 @@ ng build --configuration production
 
 ## Development Workflow
 
-1. `cd resident-ui/resident-ui` (from repo root) or just `resident-ui`
-   if you are already inside the outer `resident-ui/` checkout.
+1. `cd resident-ui` (from repo root).
 2. `npm install`.
 3. Make your change under `src/app/...`.
 4. Run `npm run lint` and `npm test` before committing.

--- a/resident-ui/AGENTS.md
+++ b/resident-ui/AGENTS.md
@@ -92,7 +92,7 @@ ng build --configuration production
 ### Do
 
 1. Run `npm install` / `npm run build` / `npm test` / `npm run lint`
-   from inside this `resident-ui/resident-ui/` directory, never the repo
+   from inside this `resident-ui/` directory, never the repo
    root.
 2. Treat `src/assets/config.json` as the file to change for API
    endpoint/base URL config — not `environment.ts`.

--- a/uitest-resident/AGENTS.md
+++ b/uitest-resident/AGENTS.md
@@ -4,11 +4,14 @@ Parent guide: [`../AGENTS.md`](../AGENTS.md)
 
 ## Purpose
 
-A Maven-based Selenium WebDriver test module ("Admin Automation") that
-drives a deployed Resident UI instance through Chrome to cover CRUD
+A Maven-based Selenium WebDriver test module that drives a deployed
+Resident UI instance through Chrome to cover CRUD
 (create/read/update/delete) flows end-to-end against a real environment.
 This is not a unit-test module — it needs a running target environment
-and a Chrome driver.
+and a Chrome driver. `uitest-resident/README.md`'s title ("Admin
+Automation") is stale — the Java package is `io.mosip.testrig.residentui.*`
+and the tests exercise Resident UI flows, not an admin console; don't be
+misled by the README title.
 
 ## Layout
 

--- a/uitest-resident/AGENTS.md
+++ b/uitest-resident/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md — uitest-resident (Selenium UI automation)
+
+Parent guide: [`../AGENTS.md`](../AGENTS.md)
+
+## Purpose
+
+A Maven-based Selenium WebDriver test module ("Admin Automation") that
+drives a deployed Resident UI instance through Chrome to cover CRUD
+(create/read/update/delete) flows end-to-end against a real environment.
+This is not a unit-test module — it needs a running target environment
+and a Chrome driver.
+
+## Layout
+
+```text
+uitest-resident/
+├── pom.xml            Maven build (Java 21, TestNG, REST Assured, Guava)
+├── src/                test source, page objects, resources
+├── Dockerfile          container image for CI/scheduled runs
+├── entrypoint.sh        container entrypoint
+└── README.md            usage notes (source of the commands below)
+```
+
+## Build & Test Commands
+
+Run from this directory:
+
+```bash
+mvn clean install
+```
+
+This produces a jar (per `pom.xml`, artifact name pattern
+`uitest-resident-<version>-jar-with-dependencies`). Per the module
+README, place the built jar in a folder alongside `src/main/resources`
+files, then run it with system properties **before** `-jar`:
+
+```bash
+java -Dpath="https://env.mosip.net/" -Duserid=user -Dpassword=pwd \
+  -jar uitest-resident-1.2.1-SNAPSHOT-jar-with-dependencies.jar
+```
+
+A `chromedriver` binary must be present under the working directory in a
+folder named `chromedriver`.
+
+## Configuration
+
+- `Config.properties` — keys include `langcode` (login page language,
+  described in `TestData.json`) and `bulkwait` (bulk-upload wait time in
+  ms).
+- `TestData.json` — `setExcludedGroups` controls which scenario tags are
+  skipped. Leave empty (`""`) to run everything, or list tag codes (e.g.
+  `"BL,CT"`) to exclude those groups. Tag codes map to scenario suites:
+  `BL` blocklisted words, `BU` bulk upload, `CTR` center, `CT` center
+  type, `DS` device spec, `D` device, `DT` device types, `DOC` document
+  categories, `DOCT` document types, `DF` dynamic field, `H` holidays,
+  `MS` machine spec, `M` machine, `MT` machine types, `T` template.
+- Credentials (`userid`/`password`) and the target `path` are passed as
+  JVM `-D` system properties at run time, never committed to
+  `Config.properties` or `TestData.json`.
+
+## Execution results
+
+- Failures: `logs/AutomationLogs.log`.
+- Results: `test-output/emailable-report.html`.
+
+## CI
+
+`.github/workflows/push-trigger.yml` builds this module with Maven
+(`build-maven-uitest-resident` job, `mosip/kattu` reusable
+`maven-build.yml@master-java21` workflow), then packages the executable
+jars and builds a local Docker image
+(`build-uitest-resident-local` / `build-docker-uitest-resident` jobs).
+Sonar analysis for this module also runs via a reusable `kattu` workflow,
+only on non-PR events.
+
+## Agent rules — Do and Do not
+
+### Do
+
+1. Run `mvn clean install` from inside `uitest-resident/`, not the repo
+   root.
+2. Pass credentials and the target environment URL as `-D` JVM system
+   properties at run time, placed before `-jar` on the command line.
+3. Use `setExcludedGroups` in `TestData.json` to scope which scenario
+   tags run, rather than deleting or commenting out test classes.
+
+### Do not
+
+1. Do not commit real credentials into `Config.properties` or
+   `TestData.json`.
+2. Do not point these tests at a production MOSIP environment without
+   confirming with the environment owner — these are CRUD tests that
+   create/modify/delete real records.
+3. Do not confuse this module's Java 21 / Maven toolchain with the
+   Angular app's Node/npm toolchain in `../resident-ui/`.


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds AGENTS.md guidance for AI coding assistants and contributors working in this repo.

## Summary

- `AGENTS.md` (root) — hub covering repo layout (resident-ui/, uitest-resident/, helm/, deploy/), tech stack, configuration/secrets handling, and PR/CI conventions, linking to the two module guides below.
- `resident-ui/AGENTS.md` — Angular 7 app: npm build/test/lint/e2e commands, runtime `config.json` vs build-time `environment.ts`, i18n bundle download-at-runtime behavior.
- `uitest-resident/AGENTS.md` — Maven/Selenium test rig: build/run commands (with correct `-D` flag placement before `-jar`), `Config.properties`/`TestData.json` configuration, scenario tags, CI wiring.

All claims (build commands, CI workflow behavior, secret-injection approach in `deploy/resident-ui/install.sh`, Dockerfile runtime i18n download) were verified against the actual files on `develop` rather than assumed.

## Test plan

- [ ] Markdown renders correctly on GitHub
- [ ] Commands in each AGENTS.md match `package.json` / `pom.xml` scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide development guidance covering project structure, workflows, configuration, testing, deployment, dependencies, and security practices.
  * Added dedicated guidance for the resident UI, including Angular development and build procedures.
  * Added dedicated UI testing guidance covering Maven, Selenium, environment safety, credentials, and test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->